### PR TITLE
Run with embedded wildfly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ target/
 web-js/nbproject/private/private.properties
 web-js/nbproject/private/private.xml
 web/nb-configuration.xml
+
+.idea/
+*.iml

--- a/README.md
+++ b/README.md
@@ -8,4 +8,7 @@ Usage
 
 Build projects with mvn package and deploy to WildFly 8.1.0.
 
-`mvn wildfly:run` (from root directory) to deploy to an embedded wildfly.
+Use `mvn wildfly:run` (from root directory) to deploy to an embedded wildfly. 
+
+The rest entrypoint is located at [http://localhost:8080/rest](http://localhost:8080/rest). 
+The rest-docs can be opened with a web browser under [http://localhost:8080/rest-docs](http://localhost:8080/rest-docs).

--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Usage
 -----
 
 Build projects with mvn package and deploy to WildFly 8.1.0.
+
+`mvn wildfly:run` (from root directory) to deploy to an embedded wildfly.

--- a/ear/pom.xml
+++ b/ear/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>parent</artifactId>
+        <groupId>de.saxsys.hypermedia</groupId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <artifactId>ear</artifactId>
+    <packaging>ear</packaging>
+
+    <name>Library EAR</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>de.saxsys.hypermedia</groupId>
+            <artifactId>rest</artifactId>
+            <version>${parent.version}</version>
+            <type>war</type>
+        </dependency>
+        <dependency>
+            <groupId>de.saxsys.hypermedia</groupId>
+            <artifactId>rest-docs</artifactId>
+            <version>${parent.version}</version>
+            <type>war</type>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>1.0.2.Final</version>
+                <configuration>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -20,5 +20,22 @@
     <modules>
         <module>rest</module>
         <module>rest-docs</module>
+        <module>ear</module>
     </modules>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.wildfly.plugins</groupId>
+                <artifactId>wildfly-maven-plugin</artifactId>
+                <version>1.0.2.Final</version>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
 </project>


### PR DESCRIPTION
This pull-request adds the configuration to run the **rest api** and **rest-docs** with an embedded wildfly from maven. To archive this a EAR maven module was added. Sadly I haven't found a way to do this without an extra EAR module.
